### PR TITLE
Manual add_check, prevents double checks

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -60,6 +60,10 @@ class Pipeline:
     def check(self, line_name, *, on_section=None):
         def wrapper(self, func):
             def _inner():
-                self.lines.append(ProductionLine(filter=[func], name=line_name, on_section=on_section))
+                self.add_check(func, line_name, on_section=on_section)
             return _inner()
         return wrapper
+    
+    def add_check(self, func, line_name, *, on_section=None):
+        if self._get_line(line_name) is None:
+            self.lines.append(ProductionLine(filter=[func], name=line_name, on_section=on_section))


### PR DESCRIPTION
Added `add_check` that both allows adding a check manually calling the function, and prevents having twice the same production line in a pipeline.
Also use this functions in the wrapper.